### PR TITLE
Remove noasm Go build tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "yarn build:wasm_exec && yarn build:wasm",
-    "build:wasm": "GOARCH=wasm GOOS=js go build -tags=noasm -o superdb.wasm.full main.go && gzip -9 superdb.wasm.full -c > superdb.wasm && rm superdb.wasm.full",
+    "build:wasm": "GOARCH=wasm GOOS=js go build -o superdb.wasm.full main.go && gzip -9 superdb.wasm.full -c > superdb.wasm && rm superdb.wasm.full",
     "build:wasm_exec": "cp $(go env GOROOT)/lib/wasm/wasm_exec.js .",
     "prepack": "yarn clean && yarn build",
     "postinstall": "yarn build",


### PR DESCRIPTION
The Go Arrow package no longer requires this for GOARCH=wasm.