### PR TITLE
upgrade super to 25b24fe2a04c4bee85a45df0e3b8809f9b5bd771

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.0
 
 require (
-	github.com/brimdata/super v0.0.0-20250820203801-202c8f127dca
+	github.com/brimdata/super v0.0.0-20250821164834-25b24fe2a04c
 	github.com/teamortix/golang-wasm/wasm v0.0.0-20230719150929-5d000994c833
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.0
 
 require (
-	github.com/brimdata/super v0.0.0-20250820180932-4f82df4c40d8
+	github.com/brimdata/super v0.0.0-20250820203801-202c8f127dca
 	github.com/teamortix/golang-wasm/wasm v0.0.0-20230719150929-5d000994c833
 )
 

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/brimdata/super v0.0.0-20250820203801-202c8f127dca h1:XttsVAYfzhEhRQP0+auwMHa9itRasIFKgKL2YKvIxts=
-github.com/brimdata/super v0.0.0-20250820203801-202c8f127dca/go.mod h1:rN0S00LiB11PMwHmYXZJFZgCZEYLb3Z/EGC78sZmMWc=
+github.com/brimdata/super v0.0.0-20250821164834-25b24fe2a04c h1:JgIwTIYbXmmWcgPdhxIf+6yARE0ygKIFUVpe6gZ7VJ4=
+github.com/brimdata/super v0.0.0-20250821164834-25b24fe2a04c/go.mod h1:rN0S00LiB11PMwHmYXZJFZgCZEYLb3Z/EGC78sZmMWc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bits-and-blooms/bitset v1.12.0 h1:U/q1fAF7xXRhFCrhROzIfffYnu+dlS38vCZtmFVPHmA=
 github.com/bits-and-blooms/bitset v1.12.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/brimdata/super v0.0.0-20250820180932-4f82df4c40d8 h1:yW39cIvRk7VptCFo+25I03XeDEr+gV5RkJa6sEaToHE=
-github.com/brimdata/super v0.0.0-20250820180932-4f82df4c40d8/go.mod h1:rN0S00LiB11PMwHmYXZJFZgCZEYLb3Z/EGC78sZmMWc=
+github.com/brimdata/super v0.0.0-20250820203801-202c8f127dca h1:XttsVAYfzhEhRQP0+auwMHa9itRasIFKgKL2YKvIxts=
+github.com/brimdata/super v0.0.0-20250820203801-202c8f127dca/go.mod h1:rN0S00LiB11PMwHmYXZJFZgCZEYLb3Z/EGC78sZmMWc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/brimdata/super/runtime"
 	"github.com/brimdata/super/sio"
 	"github.com/brimdata/super/sio/anyio"
-	"github.com/brimdata/super/zbuf"
+	"github.com/brimdata/super/sbuf"
 	"github.com/teamortix/golang-wasm/wasm"
 )
 
@@ -81,7 +81,7 @@ func zq(opts opts) wasm.Promise {
 			return "", err
 		}
 		defer query.Pull(true)
-		if err := zbuf.CopyPuller(zwc, query); err != nil {
+		if err := sbuf.CopyPuller(zwc, query); err != nil {
 			return "", err
 		}
 		if err := zwc.Close(); err != nil {

--- a/main.go
+++ b/main.go
@@ -14,9 +14,9 @@ import (
 	"github.com/brimdata/super/compiler/parser"
 	"github.com/brimdata/super/pkg/storage"
 	"github.com/brimdata/super/runtime"
+	"github.com/brimdata/super/sio"
+	"github.com/brimdata/super/sio/anyio"
 	"github.com/brimdata/super/zbuf"
-	"github.com/brimdata/super/zio"
-	"github.com/brimdata/super/zio/anyio"
 	"github.com/teamortix/golang-wasm/wasm"
 )
 
@@ -69,14 +69,14 @@ func zq(opts opts) wasm.Promise {
 		}
 		defer zr.Close()
 		var buf bytes.Buffer
-		zwc, err := anyio.NewWriter(zio.NopCloser(&buf), anyio.WriterOpts{Format: opts.OutputFormat})
+		zwc, err := anyio.NewWriter(sio.NopCloser(&buf), anyio.WriterOpts{Format: opts.OutputFormat})
 		if err != nil {
 			return "", err
 		}
 		defer zwc.Close()
 		local := storage.NewLocalEngine()
 		comp := compiler.NewCompiler(local)
-		query, err := runtime.CompileQuery(context.Background(), zctx, comp, flowgraph, []zio.Reader{zr})
+		query, err := runtime.CompileQuery(context.Background(), zctx, comp, flowgraph, []sio.Reader{zr})
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
The changes in brimdata/super#6139 and brimdata/super#6140 caused the superdb-website automation to fail when it attempted a `go get` of the latest super commit followed by a `go tidy` in this superdb-wasm repo ([link](https://github.com/brimdata/superdb-website/actions/runs/17109748980)). The changes here make those succeed now, but please scrutinize.